### PR TITLE
Fix mixup of org and repo in IssuePageList

### DIFF
--- a/src/features/issuesList/IssuesListPage.tsx
+++ b/src/features/issuesList/IssuesListPage.tsx
@@ -71,7 +71,7 @@ export const IssuesListPage = ({
 
   return (
     <div id="issue-list-page">
-      <IssuesPageHeader openIssuesCount={openIssueCount} org={org} repo={org} />
+      <IssuesPageHeader openIssuesCount={openIssueCount} org={org} repo={repo} />
       {renderedList}
       <IssuePagination
         currentPage={currentPage}


### PR DESCRIPTION
This PR fixes a mixup where the IssuePageList component passed the GitHub
org instead of the repo to IssuePageHeader.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/reduxjs/rsk-github-issues-example/5)
<!-- Reviewable:end -->
